### PR TITLE
fix: use absolute $HOME paths in home::symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ TODO: Add a short summary of this module.
 - `p6df::modules::docker::home::symlink()`
 - `p6df::modules::docker::init(_module, dir)`
   - Args:
-    - _module - 
-    - dir - 
+    - _module -
+    - dir -
 - `p6df::modules::docker::vscodes()`
 - `p6df::modules::docker::vscodes::config()`
 - `str str = p6df::modules::docker::prompt::mod()`

--- a/init.zsh
+++ b/init.zsh
@@ -85,8 +85,8 @@ p6df::modules::docker::external::brew() {
 p6df::modules::docker::home::symlink() {
 
   # Compose is now a Docker Plugin and needs to be symlinked to be found
-  p6_dir_mk ".docker/cli-plugins"
-  p6_file_symlink "$HOMEBREW_PREFIX/opt/docker-compose/bin/docker-compose" ".docker/cli-plugins/docker-compose"
+  p6_dir_mk "$HOME/.docker/cli-plugins"
+  p6_file_symlink "$HOMEBREW_PREFIX/opt/docker-compose/bin/docker-compose" "$HOME/.docker/cli-plugins/docker-compose"
 
   p6_return_void
 }


### PR DESCRIPTION
Symlink targets were using relative paths (e.g. `.aws`) instead of absolute `$HOME/.aws`. Fixes symlinks when not run from $HOME.