### PR TITLE
fix: rename external::brew() -> external::brews() to match framework dispatch

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -57,11 +57,11 @@ EOF
 ######################################################################
 #<
 #
-# Function: p6df::modules::docker::external::brew()
+# Function: p6df::modules::docker::external::brews()
 #
 #>
 ######################################################################
-p6df::modules::docker::external::brew() {
+p6df::modules::docker::external::brews() {
 
   p6df::core::homebrew::cli::brew::install --cask docker
   p6df::core::homebrew::cli::brew::install docker-compose


### PR DESCRIPTION
## Summary
- Rename `external::brew()` → `external::brews()` to match the plural form dispatched by `p6df-core/lib/module.zsh`

## Test plan
- [ ] Verify `p6df::core::module::brews` dispatch resolves correctly