### PR TITLE
chore(docker): merge home::symlink into home::symlinks, tighten .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-share/.docker/machine/cache/boot2docker.iso
-share/
+share/.docker/cli-plugins/
+share/.docker/devenvironments/
+share/.docker/scan/
+share/.docker/machine/

--- a/init.zsh
+++ b/init.zsh
@@ -79,29 +79,16 @@ p6df::modules::docker::external::brews() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::docker::home::symlink()
+# Function: p6df::modules::docker::home::symlinks()
 #
-#  Environment:	 HOMEBREW_PREFIX
+#  Environment:	 HOME HOMEBREW_PREFIX P6_DFZ_SRC_DIR
 #>
 ######################################################################
-p6df::modules::docker::home::symlink() {
+p6df::modules::docker::home::symlinks() {
 
   # Compose is now a Docker Plugin and needs to be symlinked to be found
   p6_dir_mk "$HOME/.docker/cli-plugins"
   p6_file_symlink "$HOMEBREW_PREFIX/opt/docker-compose/bin/docker-compose" "$HOME/.docker/cli-plugins/docker-compose"
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: p6df::modules::docker::home::symlinks()
-#
-#  Environment:	 HOME P6_DFZ_SRC_DIR
-#>
-######################################################################
-p6df::modules::docker::home::symlinks() {
 
   p6_file_symlink "$P6_DFZ_SRC_DIR/wrsmith108/claude-code-docker-skill/skills/docker"                                        "$HOME/.claude/skills/docker"
   p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/dockerfile-generator"              "$HOME/.claude/skills/dockerfile-generator"


### PR DESCRIPTION
## What
Merge docker-compose plugin symlink from never-called singular into auto-called plural. Tighten .gitignore.

## Why
p6df-core dispatches home::symlinks (plural) only. The broad share/ gitignore was hiding config.json and daemon.json from tracking.

## Test plan
- `p6df home symlinks` recreates docker-compose plugin symlink
- `git status` shows config.json and daemon.json as trackable

## Dependencies
None