### PR TITLE
fix(docker): rename prompt::mod to prompt::context, remove redundant init, use p6_string_space_pad

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -100,34 +100,14 @@ p6df::modules::docker::home::symlinks() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::docker::init(_module, dir)
-#
-#  Args:
-#	_module -
-#	dir -
-#
-#>
-######################################################################
-p6df::modules::docker::init() {
-  local _module="$1"
-  local dir="$2"
-
-  p6_bootstrap "$dir"
-
-  p6_return_void
-}
-
-######################################################################
-#<
-#
-# Function: str str = p6df::modules::docker::prompt::mod()
+# Function: str str = p6df::modules::docker::prompt::context()
 #
 #  Returns:
 #	str - str
 #
 #>
 ######################################################################
-p6df::modules::docker::prompt::mod() {
+p6df::modules::docker::prompt::context() {
 
   local str
   if p6_file_exists "Dockerfile"; then
@@ -135,7 +115,7 @@ p6df::modules::docker::prompt::mod() {
     if p6_string_blank "$cmd"; then
       cmd=$(p6_filter_row_select_regex '^RUN' < Dockerfile | p6_filter_row_last 1)
     fi
-    str="docker:\t\t  $cmd"
+    str="$(p6_string_space_pad "docker:" 16)$cmd"
   fi
 
   p6_return_str "$str"


### PR DESCRIPTION
## What
Renames `prompt::mod` to `prompt::context` (more accurate name for Dockerfile context display), removes the redundant `init` function (bootstrap is now handled by core), and switches label formatting to use `p6_string_space_pad` for consistent alignment.

## Why
`prompt::mod` is reserved for the new `profile::mod` dispatch. The Dockerfile-specific context rendering is better named `prompt::context`. Label padding with `p6_string_space_pad` ensures consistent column alignment across all modules.

## Test plan
- Source module, enter a directory with a Dockerfile, verify prompt context output
- Confirm no `init` or `prompt::mod` functions remain

## Dependencies
None