### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::docker::deps()
-#
-#>
-######################################################################
 p6df::modules::docker::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-zsh
@@ -18,11 +12,35 @@ p6df::modules::docker::deps() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::docker::vscodes()
-#
-#>
+p6df::modules::docker::home::symlinks() {
+
+  # Compose is now a Docker Plugin and needs to be symlinked to be found
+  p6_dir_mk "$HOME/.docker/cli-plugins"
+  p6_file_symlink "$HOMEBREW_PREFIX/opt/docker-compose/bin/docker-compose" "$HOME/.docker/cli-plugins/docker-compose"
+
+  p6_file_symlink "$P6_DFZ_SRC_DIR/wrsmith108/claude-code-docker-skill/skills/docker"                                        "$HOME/.claude/skills/docker"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/dockerfile-generator"              "$HOME/.claude/skills/dockerfile-generator"
+  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/dockerfile-validator"              "$HOME/.claude/skills/dockerfile-validator"
+
+  p6_return_void
+}
+
+######################################################################
+p6df::modules::docker::external::brews() {
+
+  p6df::core::homebrew::cli::brew::install --cask docker
+  p6df::core::homebrew::cli::brew::install docker-compose
+  p6df::core::homebrew::cli::brew::install docker-credential-helper
+  p6df::core::homebrew::cli::brew::install docker-credential-helper-ecr
+  p6df::core::homebrew::cli::brew::install docker-gen
+  p6df::core::homebrew::cli::brew::install docker-ls
+  p6df::core::homebrew::cli::brew::install docker-slim
+  p6df::core::homebrew::cli::brew::install docker-squash
+  p6df::core::homebrew::cli::brew::install dockerize
+
+  p6_return_void
+}
+
 ######################################################################
 p6df::modules::docker::vscodes() {
 
@@ -33,12 +51,6 @@ p6df::modules::docker::vscodes() {
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::docker::vscodes::config()
-#
-#>
 ######################################################################
 p6df::modules::docker::vscodes::config() {
 
@@ -57,25 +69,27 @@ EOF
 ######################################################################
 #<
 #
-# Function: p6df::modules::docker::external::brews()
+# Function: p6df::modules::docker::deps()
 #
 #>
 ######################################################################
-p6df::modules::docker::external::brews() {
-
-  p6df::core::homebrew::cli::brew::install --cask docker
-  p6df::core::homebrew::cli::brew::install docker-compose
-  p6df::core::homebrew::cli::brew::install docker-credential-helper
-  p6df::core::homebrew::cli::brew::install docker-credential-helper-ecr
-  p6df::core::homebrew::cli::brew::install docker-gen
-  p6df::core::homebrew::cli::brew::install docker-ls
-  p6df::core::homebrew::cli::brew::install docker-slim
-  p6df::core::homebrew::cli::brew::install docker-squash
-  p6df::core::homebrew::cli::brew::install dockerize
-
-  p6_return_void
-}
-
+#<
+#
+# Function: p6df::modules::docker::vscodes()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::docker::vscodes::config()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::docker::external::brews()
+#
+#>
 ######################################################################
 #<
 #
@@ -83,20 +97,6 @@ p6df::modules::docker::external::brews() {
 #
 #  Environment:	 HOME HOMEBREW_PREFIX P6_DFZ_SRC_DIR
 #>
-######################################################################
-p6df::modules::docker::home::symlinks() {
-
-  # Compose is now a Docker Plugin and needs to be symlinked to be found
-  p6_dir_mk "$HOME/.docker/cli-plugins"
-  p6_file_symlink "$HOMEBREW_PREFIX/opt/docker-compose/bin/docker-compose" "$HOME/.docker/cli-plugins/docker-compose"
-
-  p6_file_symlink "$P6_DFZ_SRC_DIR/wrsmith108/claude-code-docker-skill/skills/docker"                                        "$HOME/.claude/skills/docker"
-  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/dockerfile-generator"              "$HOME/.claude/skills/dockerfile-generator"
-  p6_file_symlink "$P6_DFZ_SRC_DIR/akin-ozer/cc-devops-skills/devops-skills-plugin/skills/dockerfile-validator"              "$HOME/.claude/skills/dockerfile-validator"
-
-  p6_return_void
-}
-
 ######################################################################
 #<
 #

--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::docker::deps()
+#
+#>
+######################################################################
 p6df::modules::docker::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-zsh
@@ -11,6 +17,13 @@ p6df::modules::docker::deps() {
   )
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::docker::home::symlinks()
+#
+#  Environment:	 HOME HOMEBREW_PREFIX P6_DFZ_SRC_DIR
+#>
 ######################################################################
 p6df::modules::docker::home::symlinks() {
 
@@ -25,6 +38,12 @@ p6df::modules::docker::home::symlinks() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::docker::external::brews()
+#
+#>
 ######################################################################
 p6df::modules::docker::external::brews() {
 
@@ -42,6 +61,12 @@ p6df::modules::docker::external::brews() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::docker::vscodes()
+#
+#>
+######################################################################
 p6df::modules::docker::vscodes() {
 
   # docker
@@ -51,6 +76,12 @@ p6df::modules::docker::vscodes() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::docker::vscodes::config()
+#
+#>
 ######################################################################
 p6df::modules::docker::vscodes::config() {
 
@@ -66,37 +97,6 @@ EOF
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::docker::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::docker::vscodes()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::docker::vscodes::config()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::docker::external::brews()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::docker::home::symlinks()
-#
-#  Environment:	 HOME HOMEBREW_PREFIX P6_DFZ_SRC_DIR
-#>
 ######################################################################
 #<
 #


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None